### PR TITLE
Commit Comparison Files: Support ignoring given file statuses

### DIFF
--- a/commit-comparison-files/action.yml
+++ b/commit-comparison-files/action.yml
@@ -13,6 +13,8 @@ inputs:
   headRef:
     required: true
     description: 'Head ref to make comparison from'
+  ignoreFilesStatuses:
+    description: 'Comma separated list of file statuses to ignore in results'
 runs:
   using: 'node12'
   main: 'index.js'

--- a/commit-comparison-files/index.js
+++ b/commit-comparison-files/index.js
@@ -9,6 +9,7 @@ async function run() {
     const token = core.getInput('token', { required: true });
     const baseRef = core.getInput('baseRef', { required: true });
     const headRef = core.getInput('headRef', { required: true });
+    const ignoreFileStatuses = core.getInput('ignoreFileStatuses').split(',') || [];
     const { owner, repo } = github.context.repo;
 
     const octokit = new github.GitHub(token);
@@ -20,7 +21,10 @@ async function run() {
       head: headRef,
     });
 
-    const files = response.data.files.map(file => file.filename);
+    const files = response.data.files
+      .filter(file => !ignoreFileStatuses.includes(file.status))
+      .map(file => file.filename);
+
     const fileFilters = Array.from(Object.entries(process.env)).reduce(
       (filters, [key, value]) => {
         if (/INPUT_(\w+)_FILES/.test(key)) {


### PR DESCRIPTION
This PR adds the ability for `commit-comparison-files` to now accept a `ignoreFileStatuses` input. This input is a comma-separated list of file statuses to ignore when generating the file listings. 